### PR TITLE
Replace __asset_map_placeholder__ in tests/index.html as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,10 @@ module.exports = {
   postBuild: function (build) {
     let fingerprintPrepend = '/';
     let indexFilePath = build.directory + '/index.html';
-    let indexFileBuffer = fs.readFileSync(indexFilePath);
-    let indexFile = indexFileBuffer.toString('utf8');
+    let testIndexFilePath = build.directory + '/tests/index.html';
+
+    let indexFile = fs.readFileSync(indexFilePath, {encoding: 'utf-8'});
+    let testIndexFile = fs.readFileSync(testIndexFilePath, {encoding: 'utf-8'});
 
     let files = fs.readdirSync(build.directory + '/assets');
     let totalFiles = files.length;
@@ -42,6 +44,11 @@ module.exports = {
       fs.writeFileSync(
         indexFilePath,
         indexFile.replace(/__asset_map_placeholder__/, fingerprintPrepend + 'assets/' + assetFileName)
+      );
+
+      fs.writeFileSync(
+        testIndexFilePath,
+        testIndexFile.replace(/__asset_map_placeholder__/, fingerprintPrepend + 'assets/' + assetFileName)
       );
     }
   },


### PR DESCRIPTION
The `__asset_map_placeholder__ ` is currently written twice from `contentFor`, once for `index.html` and once for `tests/index.html`, but `postBuild` only replaces the placeholder with the actual value in `index.html`, so any test using the service or helper will fail.