### PR TITLE
Enable embedding asset map into index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ module.exports = function(environment) {
   var ENV = {
     ...
     ifa: {
-      enabled: true
+      enabled: true,
+      [inlined: true] // If you wish to inline/embed the asset map into the index.html
     }
     ...
   };

--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -6,6 +6,7 @@ import AssetMap from '../services/asset-map';
 export function initialize(app) {
   app.deferReadiness();
 
+  let assetMapContent = window && window.__assetMapContent__;
   let assetMapFile = window && window.__assetMapFilename__;
 
   if (!assetMapFile) {
@@ -14,9 +15,15 @@ export function initialize(app) {
     return;
   }
 
-  const promise = new RSVP.Promise((resolve, reject) => {
-    $.getJSON(assetMapFile, resolve).fail(reject);
-  });
+  if (assetMapContent !== undefined) {
+    const promise = new RSVP.Promise((resolve, reject) => {
+      resolve(assetMapContent)
+    })
+  } else {
+    const promise = new RSVP.Promise((resolve, reject) => {
+      $.getJSON(assetMapFile, resolve).fail(reject);
+    });
+  }
 
   promise.then((map = {}) => {
     AssetMap.reopen({

--- a/index.js
+++ b/index.js
@@ -44,22 +44,34 @@ module.exports = {
       fingerprintPrepend = this.app.options.fingerprint.prepend;
     }
 
+    let assetMapFileName = null;
     let assetMapContent = null;
 
     if (assetFileName) {
-      assetMapContent = `"${fingerprintPrepend + 'assets/' + assetFileName}"`;
+      assetMapFileName = `"${fingerprintPrepend}assets/${assetFileName}"`;
+
+      const assetMapFilePath = `${build.directory}/assets/${assetFileName}`
+      assetMapContent = fs.readFileSync(assetMapFilePath, 'utf8')
     }
 
-    fs.writeFileSync(indexFilePath, indexFile.replace(/__asset_map_placeholder__/, assetMapContent));
+
+
+    fs.writeFileSync(indexFilePath, indexFile.replace(/__asset_map_placeholder__/, assetMapFileName));
+
+    fs.writeFileSync(indexFilePath, indexFile.replace(/__asset_map_content_placeholder__/, assetMapContent));
 
     if (testIndexFile) {
-      fs.writeFileSync(testIndexFilePath, testIndexFile.replace(/__asset_map_placeholder__/, assetMapContent));
+      fs.writeFileSync(testIndexFilePath, testIndexFile.replace(/__asset_map_placeholder__/, assetMapFileName));
     }
   },
 
   contentFor(type, config) {
     if (type === 'head-footer' && config.ifa && config.ifa.enabled) {
-      return '<script>var __assetMapFilename__ = __asset_map_placeholder__;</script>';
+      if (config.ifa.inlined) {
+        return '<script>var __assetMapContent__ = __asset_map_content_placeholder__;</script>';
+      } else {
+        return '<script>var __assetMapFilename__ = __asset_map_placeholder__;</script>';
+      }
     }
   }
 };


### PR DESCRIPTION
Implements https://github.com/RuslanZavacky/ember-cli-ifa/issues/6

The asset map is not inlined/embedded into the index.html file. This helps avoid an arguably uncessary HTTP request which delays the readiness of the app for dozens of milliseconds.