### PR TITLE
Prevent failing in FastBoot

### DIFF
--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -4,6 +4,10 @@ import $ from 'jquery';
 import AssetMap from '../services/asset-map';
 
 export function initialize(app) {
+  if (typeof FastBoot !== 'undefined') {
+    return;
+  }
+
   const container = app.__container__;
   let config;
   if(container.factoryFor) {


### PR DESCRIPTION
Follow-up to #24. This PR doesn't provide FastBoot compatibility, it merely prevents the content of the initializer to run, because the container that's required to access the service is not present in initializers. This means that assets being requested from the service in FastBoot are not correct, but at least the app won't fail to serve requests.