### PR TITLE
Use HTML meta to store asset map information

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,24 +127,6 @@ var app = new EmberApp(defaults, {
 
 ### inline option
 
-If `inline: true` is specified in config, contents of assetMap file will be inline into index.html. 
-
-```html
-<script>
-...
-
-var __assetMapPlaceholder__ = {
-  "assets": {
-    "assets/assetMap.json": "assets/assetMap-0a0447ba419421fa257963a718324fa8.json",
-    "assets/failed.png": "assets/failed-836936cf32381ff14d191d7b10be9a89.png",
-    "assets/passed.png": "assets/passed-b8506cbc195c8b9db541745aee267c48.png",
-    "assets/tomster-under-construction.png": "assets/tomster-under-construction-da524c8bc9283f759ae640b68db81f24.png"
-  },
-  "prepend": ""
-};
-</script>
-
-...
-```
+If `inline: true` is specified in config, contents of assetMap file will be inline into index.html.
 
 This might save one request to assetMap.json, but will increase overall size of `index.html` file, so use carefully.

--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -7,10 +7,7 @@ import getAssetMapData from 'ember-cli-ifa/utils/get-asset-map-data';
 export function initialize(app) {
   let assetMapFile = getAssetMapData();
 
-  // This is split out like this, in order to prevent this from being accidentally replaced
-  let replacementPath = ['__', 'asset_map_placeholder', '__'].join('');
-
-  if (!assetMapFile || assetMapFile === replacementPath) {
+  if (!assetMapFile) {
     app.register('service:asset-map', AssetMap);
     return;
   }

--- a/addon/utils/get-asset-map-data.js
+++ b/addon/utils/get-asset-map-data.js
@@ -1,7 +1,5 @@
-import $ from 'jquery';
-
 export default function getAssetMapData() {
-  const assetMapString = $("meta[name='ember-cli-ifa:assetMap']").attr('content');
+  const assetMapString = document.querySelector("meta[name='ember-cli-ifa:assetMap']").content;
   if (!assetMapString) {
     return;
   }

--- a/addon/utils/get-asset-map-data.js
+++ b/addon/utils/get-asset-map-data.js
@@ -1,4 +1,10 @@
+import $ from 'jquery';
+
 export default function getAssetMapData() {
-  // This placeholder is replaced in the build step
-  return '__asset_map_placeholder__';
+  const assetMapString = $("meta[name='ember-cli-ifa:assetMap']").attr('content');
+  if (!assetMapString) {
+    return;
+  }
+
+  return JSON.parse(decodeURIComponent(assetMapString));
 }


### PR DESCRIPTION
There are a couple downsides to rewriting vendor.js in-place, which
are documented in #36:

- It breaks SRI
- It doesn't update the fingerprint for vendor.js, even though the
  contents have changed.

This patch fixes the issue by loading the asset map information (either
a JSON object or a URL for the asset map) into a HTML meta tag that is
stored in `index.html` instead, then read at runtime by
`getAssetMapData` (the meta tag is formatted as JSON and URL-encoded).

Conceptually, this is fairly similar to the `storeConfigInMeta` option
for the Ember build that stores the app's environment in a meta tag
(https://ember-cli.com/user-guide/#application-configuration).