### PR TITLE
Passthrough fingerprinted paths

### DIFF
--- a/addon/services/asset-map.js
+++ b/addon/services/asset-map.js
@@ -6,11 +6,24 @@ export default Service.extend({
   map: computed(() => ({})),
   prepend: '/',
 
+  fullMap: computed('map', function() {
+    const map = get(this, 'map');
+    const ret = {};
+
+    const identity = Object.keys(map).forEach(k => {
+      const v = map[k];
+      ret[k] = v;
+      ret[v] = v;
+    });
+
+    return ret;
+  }),
+
   resolve(name) {
-    const map = get(this, 'map') || {};
+    const fullMap = get(this, 'fullMap') || {};
     const prepend = get(this, 'prepend');
     const enabled = get(this, 'enabled');
-    const assetName = enabled ? map[name] : name;
+    const assetName = enabled ? fullMap[name] : name;
 
     return `${prepend}${assetName}`;
   }

--- a/tests/acceptance/asset-map-test.js
+++ b/tests/acceptance/asset-map-test.js
@@ -7,6 +7,8 @@ module('Acceptance | asset map', function(hooks) {
   setupApplicationTest(hooks);
 
   test('asset map is correctly built', async function(assert) {
+    assert.expect(6);
+
     await visit('/');
 
     assert.equal(currentURL(), '/');
@@ -18,5 +20,6 @@ module('Acceptance | asset map', function(hooks) {
     let imgPaths = [].concat(...findAll('img')).map((img) => img.getAttribute('src'));
     assert.equal(imgPaths[0], imgPaths[1], 'images 1 & 2 have equal paths');
     assert.equal(imgPaths[0], imgPaths[2], 'images 1 & 3 have equal paths');
+    assert.equal(imgPaths[0], imgPaths[3], 'images 1 & 4 have equal paths');
   });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -19,4 +19,11 @@
       Asset Map Helper
     </div>
   </div>
+
+  <div>
+    <img style="max-height: 150px;" src={{asset-map 'assets/tomster-under-construction.png'}} />
+    <div style="display: flex; justify-content: center;">
+      Asset Map Helper (with string path)
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
If a path is already fingerprinted (e.g. because the {{asset-map}}
helper was used with a string that got replaced at build time), we can
return the fingerprinted file (i.e. the input we just got), rather than
`undefined`.

Note: this doesn't however require that the fingerprinted path be
correct: if it's not in the asset map, it won't be included.