### PR TITLE
Catch errors if asset-map fails to load

### DIFF
--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -42,8 +42,14 @@ export function initialize(app) {
         prepend: map.prepend,
         enabled: true
       });
-    }).then(() => {
+    })
+    .then(() => {
       app.register('service:asset-map', AssetMap);
+    })
+    .catch((err) => {
+      console.error('Failed to register service:asset-map', err);
+    })
+    .finally(() => {
       app.advanceReadiness();
     });
   }


### PR DESCRIPTION
We had an instance in our app where the asset-map failed to load, but we had provided some fallbacks, and yet our app stopped advancing. This fixes this situation; it provides a `catch` for the promise loading the asset map itself and then advances the app in a `finally` so it happens no matter what. 

I wasn't sure the best way to mock the asset-map file in tests in order to write a test to show this is working, so if anyone has suggestions for doing that please let me know. The other tests are still passing fine, though.