### PR TITLE
Make tests/index.html only use assetmap if the file exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,11 @@ module.exports = {
       assetMap = `${fingerprintPrepend}assets/${assetFileName}`;
     }
 
-    replacePlaceholder(path.join(build.directory, 'index.html'), assetMap);
-    replacePlaceholder(path.join(build.directory, 'tests/index.html'), assetMap);
+    let filePath = path.join(build.directory, 'index.html');
+    replacePlaceholder(filePath, assetMap);
+    filePath = path.join(build.directory, 'tests/index.html');  // May not exist, eg prod build
+    if(fs.existsSync(filePath)) {
+      replacePlaceholder(filePath, assetMap);
+    }
   }
 };


### PR DESCRIPTION
Otherwise production builds (that don't include tests/index.html) don't seem to work. At least for me, anyway. Mentioned in https://github.com/RuslanZavacky/ember-cli-ifa/pull/40