### PR TITLE
Remove use of .finally(), add polyfill for fetch

### DIFF
--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -36,7 +36,7 @@ export function initialize(app) {
     .catch((err) => {
       console.error('Failed to register service:asset-map', err);
     })
-    .finally(() => {
+    .then(() => {
       app.advanceReadiness();
     });
   }

--- a/addon/initializers/asset-map.js
+++ b/addon/initializers/asset-map.js
@@ -1,4 +1,4 @@
-import RSVP from 'rsvp';
+import fetch from 'fetch';
 import AssetMap from '../services/asset-map';
 import { typeOf as getTypeOf } from '@ember/utils';
 import getAssetMapData from 'ember-cli-ifa/utils/get-asset-map-data';

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-fastboot-test-helpers": "^0.2.0",
+    "ember-fetch": "^3.4.4",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.5.0",


### PR DESCRIPTION
`finally` was just used in this merged PR https://github.com/RuslanZavacky/ember-cli-ifa/pull/42

After updating to latest master, I was having a lot of troubles running my app in IE11 and Edge, getting errors like `SCRIPT438: Object doesn't support property or method 'finally'`

I thought this was odd because I was using the `includePolyfill` flag for `ember-cli-babel`, but I think that uses the `es6-promise` polyfill, which doesn't include support for `finally` https://github.com/stefanpenner/es6-promise/issues/330#issuecomment-425233364

I figured that maybe to avoid issues it's simple enough to do without it, so I replaced the `finally` logic with a `then().catch().then()` as per a SO answer here https://stackoverflow.com/a/35999141/1343694

-----

It looks like use of `fetch` was also added, in https://github.com/RuslanZavacky/ember-cli-ifa/pull/43 which still requires a polyfill for IE11, so now it's using `ember-fetch` for that