### PR TITLE
Fall back to name in resolve

### DIFF
--- a/addon/services/asset-map.js
+++ b/addon/services/asset-map.js
@@ -10,7 +10,7 @@ export default Service.extend({
     const map = get(this, 'map');
     const ret = {};
 
-    const identity = Object.keys(map).forEach(k => {
+    Object.keys(map).forEach(k => {
       const v = map[k];
       ret[k] = v;
       ret[v] = v;
@@ -23,7 +23,9 @@ export default Service.extend({
     const fullMap = get(this, 'fullMap') || {};
     const prepend = get(this, 'prepend');
     const enabled = get(this, 'enabled');
-    const assetName = enabled ? fullMap[name] : name;
+    const assetName = enabled ?
+      (fullMap[name] || name) :
+      name;
 
     return `${prepend}${assetName}`;
   }

--- a/tests/unit/services/asset-map-test.js
+++ b/tests/unit/services/asset-map-test.js
@@ -1,0 +1,75 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { set } from '@ember/object';
+
+module('Unit | Service | asset-map', function(hooks) {
+  setupTest(hooks);
+
+  module('resolve', function() {
+    test('it works with an existing name', function(assert) {
+      let service = this.owner.lookup('service:asset-map');
+      set(service, 'map', {
+        'my/file.png': 'my/file-1234.png'
+      });
+
+      let result = service.resolve('my/file.png');
+      assert.equal(result, 'my/file-1234.png');
+    });
+
+    test('it works with an existing name & prepend', function(assert) {
+      let service = this.owner.lookup('service:asset-map');
+      set(service, 'map', {
+        'my/file.png': 'my/file-1234.png'
+      });
+      set(service, 'prepend', 'https://cdn.com/');
+
+      let result = service.resolve('my/file.png');
+      assert.equal(result, 'https://cdn.com/my/file-1234.png');
+    });
+
+    test('it works when disabled', function(assert) {
+      let service = this.owner.lookup('service:asset-map');
+      set(service, 'map', {
+        'my/file.png': 'my/file-1234.png'
+      });
+      set(service, 'enabled', false);
+
+      let result = service.resolve('my/file.png');
+      assert.equal(result, 'my/file.png');
+    });
+
+    test('it works with an existing name & prepend when disabled', function(assert) {
+      let service = this.owner.lookup('service:asset-map');
+      set(service, 'map', {
+        'my/file.png': 'my/file-1234.png'
+      });
+      set(service, 'prepend', 'https://cdn.com/');
+      set(service, 'enabled', false);
+
+      let result = service.resolve('my/file.png');
+      assert.equal(result, 'https://cdn.com/my/file.png');
+    });
+
+    test('it works with a non-existing name', function(assert) {
+      let service = this.owner.lookup('service:asset-map');
+      set(service, 'map', {
+        'my/file.png': 'my/file-1234.png'
+      });
+
+      let result = service.resolve('my/file2.png');
+      assert.equal(result, 'my/file2.png');
+    });
+
+    test('it works with a non-existing name & prepend', function(assert) {
+      let service = this.owner.lookup('service:asset-map');
+      set(service, 'map', {
+        'my/file.png': 'my/file-1234.png'
+      });
+      set(service, 'prepend', 'https://cdn.com/');
+
+      let result = service.resolve('my/file2.png');
+      assert.equal(result, 'https://cdn.com/my/file2.png');
+    });
+  });
+});
+


### PR DESCRIPTION
Currently, when using `assetMap.resolve()` with a file that does not exist in the map, it returns `"undefined"` (the string, not the type). This is weird and hard to handle.

This PR ensures that if something is not found in the asset map, it just returns the name.
It also adds some tests for the different cases & resolve.