### PR TITLE
Fix broken `test/index.html` mutation

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,10 @@ module.exports = {
     }
 
     replacePlaceholder(path.join(build.directory, 'index.html'), assetMap);
-    replacePlaceholder(path.join(build.directory, 'tests/index.html'), assetMap);
+
+    let testIndexPath = path.join(build.directory, 'tests/index.html');
+    if (fs.existsSync(testIndexPath)) {
+      replacePlaceholder(testIndexPath, assetMap);
+    }
   }
 };


### PR DESCRIPTION
If `ember build -prod` is used the test file won't be built and the corresponding `fs.readFileSync()` operation would fail.

Resolves #48 