### PR TITLE
Ensure that we don't write `undefined` into the `<meta>` element value

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 const MetaPlaceholder = '__ember-cli-ifa__AssetMapPlaceholder__';
 
 function replacePlaceholder(filePath, assetMap) {
-  const assetMapString = encodeURIComponent(JSON.stringify(assetMap));
+  const assetMapString = assetMap ? encodeURIComponent(JSON.stringify(assetMap)) : '';
   const fileBody = fs.readFileSync(filePath, { encoding: 'utf-8' });
   fs.writeFileSync(filePath, fileBody.replace(MetaPlaceholder, assetMapString));
 }


### PR DESCRIPTION
This makes #40 work properly if the asset-map is only produced for production builds.

Writing `undefined` would fail https://github.com/RuslanZavacky/ember-cli-ifa/blob/master/addon/utils/get-asset-map-data.js#L7 on app boot