### PR TITLE
Fix FastBoot support

### DIFF
--- a/addon/utils/get-asset-map-data.js
+++ b/addon/utils/get-asset-map-data.js
@@ -1,4 +1,11 @@
+import require from 'require';
+
 export default function getAssetMapData() {
+  if(typeof FastBoot !== "undefined") {
+    let assetMap =  require('asset-map');
+    return assetMap.default;
+  }
+
   const assetMapString = document.querySelector("meta[name='ember-cli-ifa:assetMap']").content;
   if (!assetMapString) {
     return;

--- a/addon/utils/get-asset-map-data.js
+++ b/addon/utils/get-asset-map-data.js
@@ -2,7 +2,7 @@ import require from 'require';
 
 export default function getAssetMapData() {
   if(typeof FastBoot !== "undefined") {
-    let assetMap =  require('asset-map');
+    let assetMap = require('ember-cli-ifa/fastboot-asset-map');
     return assetMap.default;
   }
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ module.exports = {
 
   treeForFastBoot(tree) {
     this._isFastBoot = true;
+
+    if (this.project !== this.parent) {
+      this.ui.writeLine('ember-cli-ifa currently only supports being a top-level dependency! If you are seeing this message please open an issue on https://github.com/RuslanZavacky/ember-cli-ifa/issues');
+    }
+
     return tree;
   },
 

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ module.exports = {
       if(this._isFastBoot) {
         const assetModulePath = assetFileNamePath.replace(/\.json$/, '.js');
 
-        fs.writeFileSync(assetModulePath, `define('asset-map', [], function () {
+        fs.writeFileSync(assetModulePath, `define('ember-cli-ifa/fastboot-asset-map', [], function () {
           return {
             'default': ${assetMapContent},
             __esModule: true,


### PR DESCRIPTION
This is just the implementation aspect of https://github.com/RuslanZavacky/ember-cli-ifa/pull/56 without any changes to the tests. After we get this merged I will update the tests to make sure we're checking fastboot support (which we're not currently doing on master).

Essentially since `v0.8.0` fastboot support has been broken because we currently rely on the `document` to implement the inline implementation. This PR adds a fastboot-specific code-path that now works 🎉 