### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "10"
+  - "8"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "http://github.com/RuslanZavacky/ember-cli-ifa.git"
   },
   "engines": {
-    "node": ">= 6"
+    "node": "8.* || 10.* || >= 12.*"
   },
   "author": {
     "name": "Ruslan Zavacky",


### PR DESCRIPTION
... because it has officially reached its end-of-life.